### PR TITLE
[WIP] Added credits action to footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -15,6 +15,8 @@
 
 	<footer id="colophon" class="site-footer" role="contentinfo">
 		<div class="site-info">
+			<?php do_action( 'wcb2017_credits' ); ?>
+
 			<a class="site-info-generator" href="http://wordpress.org/" title="<?php esc_attr_e( 'A Semantic Personal Publishing Platform', 'wordcamporg' ); ?>" rel="generator"><?php echo esc_html( sprintf( __( 'Proudly powered by %s', 'wordcamporg' ), 'WordPress' ) ); ?></a>
 			<a class="site-info-network" href="http://central.wordcamp.org/" title="<?php esc_attr_e( 'Return to WordCamp Central', 'wordcamporg' ); ?>"><?php esc_html_e( 'Go to WordCamp Central', 'wordcamporg' ); ?></a>
 		</div><!-- .site-info -->


### PR DESCRIPTION
In the Base Redux theme, the footer had an action [`wcb_credits`](https://github.com/2ndkauboy/wordcamp-base-v2-1/blob/master/footer.php#L28) but I couldn't find any usage of it in the theme or one of the meta environment plugin. So is this action still needed?